### PR TITLE
Document 엔티티에 UUID 추가

### DIFF
--- a/src/main/java/com/FINAL/KIP/document/domain/Document.java
+++ b/src/main/java/com/FINAL/KIP/document/domain/Document.java
@@ -3,6 +3,7 @@ package com.FINAL.KIP.document.domain;
 import com.FINAL.KIP.group.domain.Group;
 import com.FINAL.KIP.common.domain.BaseEntity;
 import jakarta.persistence.*;
+import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -15,6 +16,9 @@ public class Document extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false, updatable = false)
+    private UUID uuid;
 
     @Column(nullable = false)
     private String title;
@@ -41,5 +45,9 @@ public class Document extends BaseEntity {
     public Document(String title, KmsDocType kmsDocType) {
         this.title = title;
         this.kmsDocType = kmsDocType;
+    }
+    @PrePersist
+    public void prePersist(){
+        this.uuid = UUID.randomUUID();
     }
 }

--- a/src/main/java/com/FINAL/KIP/document/repository/DocumentRepository.java
+++ b/src/main/java/com/FINAL/KIP/document/repository/DocumentRepository.java
@@ -1,10 +1,14 @@
 package com.FINAL.KIP.document.repository;
 
 import com.FINAL.KIP.document.domain.Document;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DocumentRepository extends JpaRepository<Document, Long> {
+
+	Optional<Document> findByUuid(UUID uuid);
 
 }


### PR DESCRIPTION
document 엔티티 클래스에 uuid 컬럼 추가
 - `@PrePercist` 어노테이션 사용해 엔티티 저장 전에 uuid 생성
document 레포지토리에 `findByUuid` 메서드 생성
 - 대부분의 uuid입력은 `@PathVariable` 방식으로 이루어진다고 하면 String 형태로 입력될 것
 - 따라서 `UUID.fromString(uuid)`와 같이 String을 UUID형태로 변형하여 사용하면 됨