### PR TITLE
Request create

### DIFF
--- a/src/main/java/com/FINAL/KIP/document/domain/Document.java
+++ b/src/main/java/com/FINAL/KIP/document/domain/Document.java
@@ -2,7 +2,10 @@ package com.FINAL.KIP.document.domain;
 
 import com.FINAL.KIP.common.domain.BaseEntity;
 import com.FINAL.KIP.group.domain.Group;
+import com.FINAL.KIP.request.domain.Request;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -40,6 +43,9 @@ public class Document extends BaseEntity {
     private Group group;
 
     private String delYn = "N";
+
+    @OneToMany(mappedBy = "documentId", cascade = CascadeType.ALL)
+    private final List<Request> requests = new ArrayList<>();
     public Document () {}
 
     @Builder

--- a/src/main/java/com/FINAL/KIP/group/domain/Group.java
+++ b/src/main/java/com/FINAL/KIP/group/domain/Group.java
@@ -3,6 +3,7 @@ package com.FINAL.KIP.group.domain;
 import com.FINAL.KIP.common.domain.BaseEntity;
 import com.FINAL.KIP.document.domain.Document;
 import com.FINAL.KIP.document.domain.KmsDocType;
+import com.FINAL.KIP.request.domain.Request;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -46,6 +47,9 @@ public class Group extends BaseEntity {
 
     @OneToMany(mappedBy = "group", cascade = CascadeType.PERSIST)
     private final List<Document> documents = new ArrayList<>();
+
+    @OneToMany(mappedBy = "groupId", cascade = CascadeType.ALL)
+    private final List<Request> requests = new ArrayList<>();
 
     @Builder
     public Group(String groupName, GroupType groupType) {

--- a/src/main/java/com/FINAL/KIP/request/controller/RequestController.java
+++ b/src/main/java/com/FINAL/KIP/request/controller/RequestController.java
@@ -1,0 +1,29 @@
+package com.FINAL.KIP.request.controller;
+
+import com.FINAL.KIP.request.dto.request.RequestCreateReqDto;
+import com.FINAL.KIP.request.dto.response.RequestCreateResDto;
+import com.FINAL.KIP.request.service.RequestService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class RequestController {
+
+	private final RequestService requestService;
+
+	@Autowired
+	public RequestController(RequestService requestService) {
+		this.requestService = requestService;
+	}
+
+
+	@GetMapping("/doc/request")
+	public ResponseEntity<RequestCreateResDto> createRequest(@RequestBody RequestCreateReqDto requestCreateReqDto) {
+		return requestService.createRequest(requestCreateReqDto);
+	}
+
+}

--- a/src/main/java/com/FINAL/KIP/request/domain/Request.java
+++ b/src/main/java/com/FINAL/KIP/request/domain/Request.java
@@ -5,10 +5,12 @@ import com.FINAL.KIP.document.domain.Document;
 import com.FINAL.KIP.group.domain.Group;
 import com.FINAL.KIP.user.domain.User;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
@@ -33,12 +35,15 @@ public class Request extends BaseEntity {
 	private String isOk = "P";
 
 	@ManyToOne
+	@JoinColumn(nullable = false)
 	private Document documentId;
 
 	@ManyToOne
+	@JoinColumn(nullable = false)
 	private User requesterId;
 
 	@ManyToOne
+	@JoinColumn(nullable = false)
 	private Group groupId;
 
 }

--- a/src/main/java/com/FINAL/KIP/request/domain/Request.java
+++ b/src/main/java/com/FINAL/KIP/request/domain/Request.java
@@ -1,0 +1,44 @@
+package com.FINAL.KIP.request.domain;
+
+import com.FINAL.KIP.common.domain.BaseEntity;
+import com.FINAL.KIP.document.domain.Document;
+import com.FINAL.KIP.group.domain.Group;
+import com.FINAL.KIP.user.domain.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+public class Request extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private LocalDateTime dueDate;
+
+	@Builder.Default
+	private String isOk = "P";
+
+	@ManyToOne
+	private Document documentId;
+
+	@ManyToOne
+	private User requesterId;
+
+	@ManyToOne
+	private Group groupId;
+
+}

--- a/src/main/java/com/FINAL/KIP/request/domain/Request.java
+++ b/src/main/java/com/FINAL/KIP/request/domain/Request.java
@@ -34,6 +34,8 @@ public class Request extends BaseEntity {
 	@Builder.Default
 	private String isOk = "P";
 
+	private int days;
+
 	@ManyToOne
 	@JoinColumn(nullable = false)
 	private Document documentId;

--- a/src/main/java/com/FINAL/KIP/request/dto/request/RequestCreateReqDto.java
+++ b/src/main/java/com/FINAL/KIP/request/dto/request/RequestCreateReqDto.java
@@ -7,6 +7,6 @@ public class RequestCreateReqDto {
 
 	private String docId;
 	private Long userId;
-	private int expiration;
+	private int days;
 
 }

--- a/src/main/java/com/FINAL/KIP/request/dto/request/RequestCreateReqDto.java
+++ b/src/main/java/com/FINAL/KIP/request/dto/request/RequestCreateReqDto.java
@@ -1,0 +1,12 @@
+package com.FINAL.KIP.request.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class RequestCreateReqDto {
+
+	private String docId;
+	private Long userId;
+	private int expiration;
+
+}

--- a/src/main/java/com/FINAL/KIP/request/dto/response/RequestCreateResDto.java
+++ b/src/main/java/com/FINAL/KIP/request/dto/response/RequestCreateResDto.java
@@ -9,6 +9,6 @@ import lombok.Setter;
 public class RequestCreateResDto {
 
 	String docTitle;
-	LocalDateTime requestTime;
+	int days;
 
 }

--- a/src/main/java/com/FINAL/KIP/request/dto/response/RequestCreateResDto.java
+++ b/src/main/java/com/FINAL/KIP/request/dto/response/RequestCreateResDto.java
@@ -1,0 +1,14 @@
+package com.FINAL.KIP.request.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RequestCreateResDto {
+
+	String docTitle;
+	LocalDateTime requestTime;
+
+}

--- a/src/main/java/com/FINAL/KIP/request/repository/RequestRepository.java
+++ b/src/main/java/com/FINAL/KIP/request/repository/RequestRepository.java
@@ -1,0 +1,8 @@
+package com.FINAL.KIP.request.repository;
+
+import com.FINAL.KIP.request.domain.Request;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RequestRepository extends JpaRepository<Request, Long> {
+
+}

--- a/src/main/java/com/FINAL/KIP/request/service/RequestService.java
+++ b/src/main/java/com/FINAL/KIP/request/service/RequestService.java
@@ -1,0 +1,65 @@
+package com.FINAL.KIP.request.service;
+
+import com.FINAL.KIP.document.domain.Document;
+import com.FINAL.KIP.document.repository.DocumentRepository;
+import com.FINAL.KIP.request.domain.Request;
+import com.FINAL.KIP.request.dto.request.RequestCreateReqDto;
+import com.FINAL.KIP.request.dto.response.RequestCreateResDto;
+import com.FINAL.KIP.request.repository.RequestRepository;
+import com.FINAL.KIP.user.domain.User;
+import com.FINAL.KIP.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class RequestService {
+
+	private final RequestRepository requestRepository;
+	private final DocumentRepository documentRepository;
+	private final UserRepository userRepository;
+
+	@Autowired
+	public RequestService(RequestRepository requestRepository,
+		DocumentRepository documentRepository,
+		UserRepository userRepository) {
+		this.requestRepository = requestRepository;
+		this.documentRepository = documentRepository;
+		this.userRepository = userRepository;
+	}
+
+	@Transactional
+	public ResponseEntity<RequestCreateResDto> createRequest(RequestCreateReqDto requestCreateReqDto) {
+
+		Document document = findDocumentByUuid(requestCreateReqDto.getDocId());
+		User user = findUserById(requestCreateReqDto.getUserId());
+		Request request = Request.builder()
+			.requesterId(user)
+			.dueDate(LocalDateTime.now().plusDays(requestCreateReqDto.getExpiration()))
+			.documentId(document)
+			.groupId(document.getGroup())
+			.build();
+		requestRepository.save(request);
+
+		RequestCreateResDto requestCreateResDto = new RequestCreateResDto();
+		requestCreateResDto.setDocTitle(document.getTitle());
+		requestCreateResDto.setRequestTime(request.getDueDate());
+		return new ResponseEntity<>(requestCreateResDto, HttpStatus.CREATED);
+	}
+
+
+	public User findUserById(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+	}
+	public Document findDocumentByUuid(String uuid) {
+		UUID id = UUID.fromString(uuid);
+		return documentRepository.findByUuid(id)
+			.orElseThrow(() -> new IllegalArgumentException("해당되는 문서가 존재하지 않습니다"));
+	}
+}

--- a/src/main/java/com/FINAL/KIP/request/service/RequestService.java
+++ b/src/main/java/com/FINAL/KIP/request/service/RequestService.java
@@ -2,11 +2,16 @@ package com.FINAL.KIP.request.service;
 
 import com.FINAL.KIP.document.domain.Document;
 import com.FINAL.KIP.document.repository.DocumentRepository;
+import com.FINAL.KIP.group.domain.Group;
+import com.FINAL.KIP.group.domain.GroupUser;
+import com.FINAL.KIP.group.domain.GroupUserId;
+import com.FINAL.KIP.group.repository.GroupUserRepository;
 import com.FINAL.KIP.request.domain.Request;
 import com.FINAL.KIP.request.dto.request.RequestCreateReqDto;
 import com.FINAL.KIP.request.dto.response.RequestCreateResDto;
 import com.FINAL.KIP.request.repository.RequestRepository;
 import com.FINAL.KIP.user.domain.User;
+import com.FINAL.KIP.user.domain.UserDocAuthorityId;
 import com.FINAL.KIP.user.repository.UserRepository;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -19,47 +24,75 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class RequestService {
+	private final GroupUserRepository groupUserRepository;
 
 	private final RequestRepository requestRepository;
 	private final DocumentRepository documentRepository;
 	private final UserRepository userRepository;
 
 	@Autowired
-	public RequestService(RequestRepository requestRepository,
-		DocumentRepository documentRepository,
-		UserRepository userRepository) {
+	public RequestService(GroupUserRepository groupUserRepository,
+		RequestRepository requestRepository,
+		DocumentRepository documentRepository, UserRepository userRepository) {
+		this.groupUserRepository = groupUserRepository;
 		this.requestRepository = requestRepository;
 		this.documentRepository = documentRepository;
 		this.userRepository = userRepository;
 	}
 
+
 	@Transactional
-	public ResponseEntity<RequestCreateResDto> createRequest(RequestCreateReqDto requestCreateReqDto) {
+	public ResponseEntity<RequestCreateResDto> createRequest(
+		RequestCreateReqDto requestCreateReqDto) throws IllegalArgumentException {
 
 		Document document = findDocumentByUuid(requestCreateReqDto.getDocId());
 		User user = findUserById(requestCreateReqDto.getUserId());
+
+		if (duplicateAuthority(user, document)) {
+			throw new IllegalArgumentException("이미 해당 문서의 접근권한을 가지고 있습니다");
+		}
 		Request request = Request.builder()
 			.requesterId(user)
-			.dueDate(LocalDateTime.now().plusDays(requestCreateReqDto.getExpiration()))
 			.documentId(document)
 			.groupId(document.getGroup())
+			.days(requestCreateReqDto.getDays())
 			.build();
 		requestRepository.save(request);
 
 		RequestCreateResDto requestCreateResDto = new RequestCreateResDto();
 		requestCreateResDto.setDocTitle(document.getTitle());
-		requestCreateResDto.setRequestTime(request.getDueDate());
+		requestCreateResDto.setDays(request.getDays());
 		return new ResponseEntity<>(requestCreateResDto, HttpStatus.CREATED);
 	}
 
 
-	public User findUserById(Long userId) {
+	private User findUserById(Long userId) {
 		return userRepository.findById(userId)
 			.orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
 	}
-	public Document findDocumentByUuid(String uuid) {
+	private Document findDocumentByUuid(String uuid) {
 		UUID id = UUID.fromString(uuid);
 		return documentRepository.findByUuid(id)
 			.orElseThrow(() -> new IllegalArgumentException("해당되는 문서가 존재하지 않습니다"));
 	}
+
+	private boolean duplicateAuthority(User user, Document document) {
+		Group group = document.getGroup();
+
+		boolean authorityCheck = false;
+
+		GroupUser groupUser = findGroupUser(group, user);
+
+		if(groupUser != null) {
+			authorityCheck = true;
+		}
+
+		return authorityCheck;
+	}
+
+	private GroupUser findGroupUser(Group group, User user) {
+		return groupUserRepository.findByGroupAndUser(group, user).orElse(null);
+	}
+
+
 }

--- a/src/main/java/com/FINAL/KIP/user/domain/User.java
+++ b/src/main/java/com/FINAL/KIP/user/domain/User.java
@@ -1,7 +1,11 @@
 package com.FINAL.KIP.user.domain;
 
 import com.FINAL.KIP.common.domain.BaseEntity;
+import com.FINAL.KIP.document.domain.Document;
+import com.FINAL.KIP.request.domain.Request;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -38,6 +42,10 @@ public class User extends BaseEntity {
 
     @Setter
     private String delYn = "N";
+
+    @OneToMany(mappedBy = "requesterId", cascade = CascadeType.ALL)
+    private final List<Request> requests = new ArrayList<>();
+
     public User(){}
 
     @Builder


### PR DESCRIPTION
 1. `Document`, `Group`과 `User` 엔티티에 `Request` 연관 관계 매핑
 2.  `RequestController` 생성 및 `Request` 생성 로직 구현
 3. `Request` 엔티티 클래스 생성
 4. 요청과 응답을 위한 Dto 생성
 5. `RequestRepository` 생성
 6. `RequestService` 생성
  - `duplicateAuthority` 메서드를 통하여 요청한 유저가 문서의 권한을 이미 가지고 있는지 검증
  - 접근 권한이 없다면, 요청 생성.
  - 접근 권한이 있다면, `IllegalArgumentException`