### PR TITLE
[refactor] Request 중복 체크 구현

### DIFF
--- a/src/main/java/com/FINAL/KIP/document/domain/Document.java
+++ b/src/main/java/com/FINAL/KIP/document/domain/Document.java
@@ -44,7 +44,7 @@ public class Document extends BaseEntity {
 
     private String delYn = "N";
 
-    @OneToMany(mappedBy = "documentId", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "document", cascade = CascadeType.ALL)
     private final List<Request> requests = new ArrayList<>();
     public Document () {}
 

--- a/src/main/java/com/FINAL/KIP/group/domain/Group.java
+++ b/src/main/java/com/FINAL/KIP/group/domain/Group.java
@@ -48,7 +48,7 @@ public class Group extends BaseEntity {
     @OneToMany(mappedBy = "group", cascade = CascadeType.PERSIST)
     private final List<Document> documents = new ArrayList<>();
 
-    @OneToMany(mappedBy = "groupId", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "group", cascade = CascadeType.ALL)
     private final List<Request> requests = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/FINAL/KIP/request/domain/Request.java
+++ b/src/main/java/com/FINAL/KIP/request/domain/Request.java
@@ -38,14 +38,14 @@ public class Request extends BaseEntity {
 
 	@ManyToOne
 	@JoinColumn(nullable = false)
-	private Document documentId;
+	private Document document;
 
 	@ManyToOne
 	@JoinColumn(nullable = false)
-	private User requesterId;
+	private User requester;
 
 	@ManyToOne
 	@JoinColumn(nullable = false)
-	private Group groupId;
+	private Group group;
 
 }

--- a/src/main/java/com/FINAL/KIP/request/repository/RequestRepository.java
+++ b/src/main/java/com/FINAL/KIP/request/repository/RequestRepository.java
@@ -1,8 +1,15 @@
 package com.FINAL.KIP.request.repository;
 
+import com.FINAL.KIP.document.domain.Document;
 import com.FINAL.KIP.request.domain.Request;
+import com.FINAL.KIP.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RequestRepository extends JpaRepository<Request, Long> {
+
+	Boolean existsRequestByRequesterAndDocumentAndIsOk(User requester, Document document, String isOk);
+
+
 
 }

--- a/src/main/java/com/FINAL/KIP/request/service/RequestService.java
+++ b/src/main/java/com/FINAL/KIP/request/service/RequestService.java
@@ -48,13 +48,16 @@ public class RequestService {
 		Document document = findDocumentByUuid(requestCreateReqDto.getDocId());
 		User user = findUserById(requestCreateReqDto.getUserId());
 
+		if (requestRepository.existsRequestByRequesterAndDocumentAndIsOk(user, document, "P")) {
+			throw new IllegalArgumentException("이미 해당 문서에 접근 권한요청을 했습니다.");
+		}
 		if (duplicateAuthority(user, document)) {
 			throw new IllegalArgumentException("이미 해당 문서의 접근권한을 가지고 있습니다");
 		}
 		Request request = Request.builder()
-			.requesterId(user)
-			.documentId(document)
-			.groupId(document.getGroup())
+			.requester(user)
+			.document(document)
+			.group(document.getGroup())
 			.days(requestCreateReqDto.getDays())
 			.build();
 		requestRepository.save(request);
@@ -89,6 +92,7 @@ public class RequestService {
 
 		return authorityCheck;
 	}
+
 
 	private GroupUser findGroupUser(Group group, User user) {
 		return groupUserRepository.findByGroupAndUser(group, user).orElse(null);

--- a/src/main/java/com/FINAL/KIP/user/domain/User.java
+++ b/src/main/java/com/FINAL/KIP/user/domain/User.java
@@ -43,7 +43,7 @@ public class User extends BaseEntity {
     @Setter
     private String delYn = "N";
 
-    @OneToMany(mappedBy = "requesterId", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "requester", cascade = CascadeType.ALL)
     private final List<Request> requests = new ArrayList<>();
 
     public User(){}


### PR DESCRIPTION
- `Request`
  1. 연관관계 네이밍 변경 ex) `documentId` -> `document`
  2. `existsRequestByRequesterAndDocumentAndIsOk`를 통해서 요청자가 접근 권한을 요청한 문서에 상태가 P인 요청이 있으면
  `IllegalArgumentException`