### PR TITLE
Document read public

### DIFF
--- a/src/main/java/com/FINAL/KIP/common/InitialDataLoader.java
+++ b/src/main/java/com/FINAL/KIP/common/InitialDataLoader.java
@@ -19,7 +19,7 @@ public InitialDataLoader(UserRepository userRepository, PasswordEncoder password
 
     @Override
     public void run(String... args) throws Exception {
-        if (userRepository.findByEmployeeId("admin@test.com").isEmpty()) {
+        if (userRepository.findByEmployeeId("KK").isEmpty()) {
             User adminMember = User.builder()
                     .name("admin")
                     .email("admin@test.com")

--- a/src/main/java/com/FINAL/KIP/document/controller/DocumentController.java
+++ b/src/main/java/com/FINAL/KIP/document/controller/DocumentController.java
@@ -1,17 +1,16 @@
 package com.FINAL.KIP.document.controller;
 
 
-import com.FINAL.KIP.document.domain.Document;
 import com.FINAL.KIP.document.dto.req.CreateDocumentReqDto;
 import com.FINAL.KIP.document.dto.res.DocumentResDto;
 import com.FINAL.KIP.document.dto.res.GetDocumentResDto;
+import com.FINAL.KIP.document.dto.res.PublicDocResDto;
 import com.FINAL.KIP.document.service.DocumentService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("doc")
@@ -31,6 +30,11 @@ public class DocumentController {
     }
 
 //    Read
+    @GetMapping
+    public ResponseEntity<List<PublicDocResDto>> getPublicDocuments(){
+        return ResponseEntity.ok(documentService.getPublicDocuments());
+    }
+
     @GetMapping("{docId}/{userId}")
     public ResponseEntity<GetDocumentResDto> getDocument(@PathVariable Long docId,
                                                          @PathVariable Long userId) {

--- a/src/main/java/com/FINAL/KIP/document/domain/Document.java
+++ b/src/main/java/com/FINAL/KIP/document/domain/Document.java
@@ -4,12 +4,12 @@ import com.FINAL.KIP.common.domain.BaseEntity;
 import com.FINAL.KIP.group.domain.Group;
 import com.FINAL.KIP.request.domain.Request;
 import jakarta.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -39,7 +39,7 @@ public class Document extends BaseEntity {
     private Document downLink;
 
     @ManyToOne
-    @JoinColumn(nullable = false)
+    @JoinColumn
     private Group group;
 
     private String delYn = "N";

--- a/src/main/java/com/FINAL/KIP/document/dto/res/DocumentResDto.java
+++ b/src/main/java/com/FINAL/KIP/document/dto/res/DocumentResDto.java
@@ -13,8 +13,8 @@ public class DocumentResDto {
     private String upDocTitle;
     private Long downLinkId;
     private String downDocTitle;
-    private final Long groupId;
-    private final String groupName;
+    private Long groupId;
+    private String groupName;
 
     public DocumentResDto(Document document) {
         this.title = document.getTitle();
@@ -29,8 +29,9 @@ public class DocumentResDto {
             this.downLinkId = document.getDownLink().getId();
             this.downDocTitle = document.getDownLink().getTitle();
         }
-
-        this.groupId = document.getGroup().getId();
-        this.groupName = document.getGroup().getGroupName();
+        if (document.getGroup() != null) {
+            this.groupId = document.getGroup().getId();
+            this.groupName = document.getGroup().getGroupName();
+        }
     }
 }

--- a/src/main/java/com/FINAL/KIP/document/dto/res/PublicDocResDto.java
+++ b/src/main/java/com/FINAL/KIP/document/dto/res/PublicDocResDto.java
@@ -1,0 +1,19 @@
+package com.FINAL.KIP.document.dto.res;
+
+import com.FINAL.KIP.document.domain.Document;
+import com.FINAL.KIP.document.domain.KmsDocType;
+import lombok.Getter;
+
+@Getter
+public class PublicDocResDto {
+
+    private final String discription = "전체공개";
+    private final String title;
+    private final KmsDocType kmsDocType;
+
+
+    public PublicDocResDto(Document document) {
+        this.title = document.getTitle();
+        this.kmsDocType = document.getKmsDocType();
+    }
+}

--- a/src/main/java/com/FINAL/KIP/document/service/DocumentService.java
+++ b/src/main/java/com/FINAL/KIP/document/service/DocumentService.java
@@ -39,23 +39,23 @@ public class DocumentService {
 //    Create
     @Transactional
     public DocumentResDto createDocument(CreateDocumentReqDto dto) {
-        Document upDocumnet = getDocumentById(dto.getUpLinkId());
+        Document upDocument = getDocumentById(dto.getUpLinkId());
 
         Document newDocument = dto.makeDocDtoToDocument();
-        newDocument.setUpLink(upDocumnet);
+        newDocument.setUpLink(upDocument);
 
-        Document downDocumnet = upDocumnet.getDownLink();
-        newDocument.setDownLink(downDocumnet);
+        Document downDocument = upDocument.getDownLink();
+        newDocument.setDownLink(downDocument);
 
         Group group = groupService.getGroupById(dto.getGroupId());
         newDocument.setGroup(group);
 
-        Document savedDocumnet = documentRepo.save(newDocument);
-        upDocumnet.setDownLink(savedDocumnet);
+        Document savedDocument = documentRepo.save(newDocument);
+        upDocument.setDownLink(savedDocument);
 
-        if(downDocumnet != null)
-            downDocumnet.setUpLink(savedDocumnet);
-        return new DocumentResDto(savedDocumnet);
+        if(downDocument != null)
+            downDocument.setUpLink(savedDocument);
+        return new DocumentResDto(savedDocument);
 
     }
 
@@ -83,10 +83,10 @@ public class DocumentService {
     public List<GetDocumentResDto> getLinkedDocumentsByGroup(Long groupId) {
         List<Document> linkedDocuments = new ArrayList<>();
         Group targetGroup = groupService.getGroupById(groupId);
-        Document topDocumnet = getTopDocumnet(targetGroup);
+        Document topDocument = getTopDocument(targetGroup);
 
-        linkedDocuments.add(topDocumnet);
-        Document currentDocument = topDocumnet;
+        linkedDocuments.add(topDocument);
+        Document currentDocument = topDocument;
         while (currentDocument.getDownLink() != null) {
             currentDocument = currentDocument.getDownLink();
             linkedDocuments.add(currentDocument);
@@ -104,7 +104,7 @@ public class DocumentService {
         return documentRepo.findById(documentId)
                 .orElseThrow(()-> new NoSuchElementException("찾으시려는 문서 ID와 일치하는 문서가 없습니다."));
     }
-    private Document getTopDocumnet(Group targetGroup) {
+    private Document getTopDocument(Group targetGroup) {
         return targetGroup.getDocuments().stream()
                 .filter(document -> document.getUpLink() == null)
                 .findFirst()

--- a/src/main/java/com/FINAL/KIP/document/service/DocumentService.java
+++ b/src/main/java/com/FINAL/KIP/document/service/DocumentService.java
@@ -4,6 +4,7 @@ import com.FINAL.KIP.document.domain.Document;
 import com.FINAL.KIP.document.dto.req.CreateDocumentReqDto;
 import com.FINAL.KIP.document.dto.res.DocumentResDto;
 import com.FINAL.KIP.document.dto.res.GetDocumentResDto;
+import com.FINAL.KIP.document.dto.res.PublicDocResDto;
 import com.FINAL.KIP.document.repository.DocumentRepository;
 import com.FINAL.KIP.group.domain.Group;
 import com.FINAL.KIP.group.domain.UserIdAndGroupRole;
@@ -36,31 +37,44 @@ public class DocumentService {
         this.userService = userService;
     }
 
-//    Create
+    //    Create
     @Transactional
     public DocumentResDto createDocument(CreateDocumentReqDto dto) {
-        Document upDocument = getDocumentById(dto.getUpLinkId());
+        if (dto.getGroupId() == null) {
+            System.out.println("hi");
+            return new DocumentResDto(
+                    documentRepo.save(
+                            dto.makeDocDtoToDocument()));
+        } else {
+            Document upDocument = getDocumentById(dto.getUpLinkId());
 
-        Document newDocument = dto.makeDocDtoToDocument();
-        newDocument.setUpLink(upDocument);
+            Document newDocument = dto.makeDocDtoToDocument();
+            newDocument.setUpLink(upDocument);
 
-        Document downDocument = upDocument.getDownLink();
-        newDocument.setDownLink(downDocument);
+            Document downDocument = upDocument.getDownLink();
+            newDocument.setDownLink(downDocument);
 
-        Group group = groupService.getGroupById(dto.getGroupId());
-        newDocument.setGroup(group);
+            Group group = groupService.getGroupById(dto.getGroupId());
+            newDocument.setGroup(group);
 
-        Document savedDocument = documentRepo.save(newDocument);
-        upDocument.setDownLink(savedDocument);
+            Document savedDocument = documentRepo.save(newDocument);
+            upDocument.setDownLink(savedDocument);
 
-        if(downDocument != null)
-            downDocument.setUpLink(savedDocument);
-        return new DocumentResDto(savedDocument);
-
+            if (downDocument != null)
+                downDocument.setUpLink(savedDocument);
+            return new DocumentResDto(savedDocument);
+        }
     }
 
-//    Read
-    public GetDocumentResDto GetIsAccessibleDoc(Long docId, Long userId){
+    //    Read
+    public List<PublicDocResDto> getPublicDocuments() {
+        return documentRepo.findAll().stream()
+                .filter(document -> document.getGroup() == null)
+                .map(PublicDocResDto::new)
+                .collect(Collectors.toList());
+    }
+
+    public GetDocumentResDto GetIsAccessibleDoc(Long docId, Long userId) {
         boolean isAccessible = false;
         Document tryToOpenDocument = getDocumentById(docId);
         User tryUser = userService.getUserById(userId);
@@ -68,17 +82,18 @@ public class DocumentService {
         Long GroupId = tryToOpenDocument.getGroup().getId();
 
         List<UserIdAndGroupRole> accessibleUsers = groupService.getAccessibleUsers(GroupId);
-        for(UserIdAndGroupRole obj : accessibleUsers) {
+        for (UserIdAndGroupRole obj : accessibleUsers) {
             System.out.println(
                     "맴버 아이디: " + obj.getUserId() + " " +
-                    userService.getUserById(obj.getUserId()).getName() +
-                    " / 권한정보: " + obj.getGroupRole());
+                            userService.getUserById(obj.getUserId()).getName() +
+                            " / 권한정보: " + obj.getGroupRole());
         }
         isAccessible = accessibleUsers.stream()
                 .anyMatch(reqUserId -> reqUserId.getUserId().equals(tryUser.getId()));
 
         return new GetDocumentResDto(tryToOpenDocument, isAccessible);
     }
+
 
     public List<GetDocumentResDto> getLinkedDocumentsByGroup(Long groupId) {
         List<Document> linkedDocuments = new ArrayList<>();
@@ -97,13 +112,13 @@ public class DocumentService {
                 .collect(Collectors.toList());
     }
 
-
 //    중복함수
 
-    public Document getDocumentById (Long documentId){
+    public Document getDocumentById(Long documentId) {
         return documentRepo.findById(documentId)
-                .orElseThrow(()-> new NoSuchElementException("찾으시려는 문서 ID와 일치하는 문서가 없습니다."));
+                .orElseThrow(() -> new NoSuchElementException("찾으시려는 문서 ID와 일치하는 문서가 없습니다."));
     }
+
     private Document getTopDocument(Group targetGroup) {
         return targetGroup.getDocuments().stream()
                 .filter(document -> document.getUpLink() == null)


### PR DESCRIPTION
src/main/java/com/FINAL/KIP/common/InitialDataLoader.java
 - YML 업데이트사용시 사번으로 조회 (이메일로 써있어서 중복되었었음)
 
 src/main/java/com/FINAL/KIP/document/domain/Document.java
 - 그룹아이디 널 허용
 
 src/main/java/com/FINAL/KIP/document/dto/res/DocumentResDto.java
 - 그룹내 새로운 문서 생성하는 함수와 Create ResDto 함께쓰기위해 널처리.
 
 src/main/java/com/FINAL/KIP/document/dto/res/PublicDocResDto.java
 - 전체공개 설명달아서 문서 제목 조회전용 ResDto 생성
 
 src/main/java/com/FINAL/KIP/document/service/DocumentService.java
 - 전체공개 문서 생성시 그룹아이디 없는경우 조건처리 
 - 약간의 소스코드 줄맞춤
 
