### PR TITLE
[feat] 요청 거부 구현, User-login 부분 수정

### DIFF
--- a/src/main/java/com/FINAL/KIP/request/controller/RequestController.java
+++ b/src/main/java/com/FINAL/KIP/request/controller/RequestController.java
@@ -2,6 +2,7 @@ package com.FINAL.KIP.request.controller;
 
 import com.FINAL.KIP.request.dto.request.RequestCreateReqDto;
 import com.FINAL.KIP.request.dto.response.RequestCreateResDto;
+import com.FINAL.KIP.request.dto.response.RequestRefuseResDto;
 import com.FINAL.KIP.request.service.RequestService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +25,11 @@ public class RequestController {
 	@GetMapping("/doc/request")
 	public ResponseEntity<RequestCreateResDto> createRequest(@RequestBody RequestCreateReqDto requestCreateReqDto) {
 		return requestService.createRequest(requestCreateReqDto);
+	}
+
+	@GetMapping("/doc/request/refuse/{request_id}")
+	public ResponseEntity<RequestRefuseResDto> refuseRequest(@PathVariable Long request_id) {
+		return requestService.refuseRequest(request_id);
 	}
 
 }

--- a/src/main/java/com/FINAL/KIP/request/domain/Request.java
+++ b/src/main/java/com/FINAL/KIP/request/domain/Request.java
@@ -48,4 +48,7 @@ public class Request extends BaseEntity {
 	@JoinColumn(nullable = false)
 	private Group group;
 
+	public void refuseRequest() {
+		this.isOk = "N";
+	}
 }

--- a/src/main/java/com/FINAL/KIP/request/dto/response/RequestRefuseResDto.java
+++ b/src/main/java/com/FINAL/KIP/request/dto/response/RequestRefuseResDto.java
@@ -1,0 +1,13 @@
+package com.FINAL.KIP.request.dto.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RequestRefuseResDto {
+
+	String title;
+	String name;
+
+}

--- a/src/main/java/com/FINAL/KIP/request/service/RequestService.java
+++ b/src/main/java/com/FINAL/KIP/request/service/RequestService.java
@@ -3,12 +3,14 @@ package com.FINAL.KIP.request.service;
 import com.FINAL.KIP.document.domain.Document;
 import com.FINAL.KIP.document.repository.DocumentRepository;
 import com.FINAL.KIP.group.domain.Group;
+import com.FINAL.KIP.group.domain.GroupRole;
 import com.FINAL.KIP.group.domain.GroupUser;
 import com.FINAL.KIP.group.domain.GroupUserId;
 import com.FINAL.KIP.group.repository.GroupUserRepository;
 import com.FINAL.KIP.request.domain.Request;
 import com.FINAL.KIP.request.dto.request.RequestCreateReqDto;
 import com.FINAL.KIP.request.dto.response.RequestCreateResDto;
+import com.FINAL.KIP.request.dto.response.RequestRefuseResDto;
 import com.FINAL.KIP.request.repository.RequestRepository;
 import com.FINAL.KIP.user.domain.User;
 import com.FINAL.KIP.user.domain.UserDocAuthorityId;
@@ -19,6 +21,7 @@ import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -99,4 +102,37 @@ public class RequestService {
 	}
 
 
+	@Transactional
+	public ResponseEntity<RequestRefuseResDto> refuseRequest(Long requestId) {
+		Request req = findById(requestId);
+		String employeeId = SecurityContextHolder.getContext().getAuthentication().getName();
+		User user = findByEmployeeId(employeeId);
+
+		Group group = req.getGroup();
+
+		GroupUser groupUser = findGroupUser(group, user);
+		if(groupUser == null) {
+			throw new IllegalArgumentException("해당 그룹 요청에 접근 권한이 존재하지 않습니다.");
+		}
+		if (groupUser.getGroupRole() != GroupRole.SUPER) {
+			throw new IllegalArgumentException("그룹의 관리자만 요청을 관리할 수 있습니다.");
+		}
+
+		req.refuseRequest();
+
+		RequestRefuseResDto requestRefuseResDto = new RequestRefuseResDto();
+		requestRefuseResDto.setTitle(req.getDocument().getTitle());
+		requestRefuseResDto.setName(req.getRequester().getName());
+		return ResponseEntity.ok(requestRefuseResDto);
+	}
+
+	private Request findById(Long requestId) {
+		return requestRepository.findById(requestId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 문서가 존재하지 않습니다."));
+	}
+
+	private User findByEmployeeId(String employeeId) {
+		return userRepository.findByEmployeeId(employeeId)
+			.orElseThrow(() -> new IllegalArgumentException("사번이 잘못되었습니다."));
+	}
 }

--- a/src/main/java/com/FINAL/KIP/user/dto/req/CreateUserReqDto.java
+++ b/src/main/java/com/FINAL/KIP/user/dto/req/CreateUserReqDto.java
@@ -3,11 +3,13 @@ package com.FINAL.KIP.user.dto.req;
 
 import com.FINAL.KIP.user.domain.Role;
 import com.FINAL.KIP.user.domain.User;
+import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Setter
+@Getter
 public class CreateUserReqDto {
     private String name;
     private String email;

--- a/src/main/java/com/FINAL/KIP/user/service/UserService.java
+++ b/src/main/java/com/FINAL/KIP/user/service/UserService.java
@@ -33,11 +33,15 @@ public class UserService {
     }
 
     public List<UserResDto> createUsers(List<CreateUserReqDto> dtos) {
+        for (CreateUserReqDto createUserReqDto : dtos) {
+            createUserReqDto.setPassword(
+                passwordEncoder.encode(createUserReqDto.makeUserReqDtoToUser().getPassword()));
+        }
         return dtos.stream()
-                .map(CreateUserReqDto::makeUserReqDtoToUser)
-                .map(userRepo::save)
-                .map(UserResDto::new)
-                .collect(Collectors.toList());
+            .map(CreateUserReqDto::makeUserReqDtoToUser)
+            .map(userRepo::save)
+            .map(UserResDto::new)
+            .collect(Collectors.toList());
     }
 
 //    Read


### PR DESCRIPTION
- `RequestController`
       1. 요청 거부 Mapping
- `Request`
        1. 요청 거부시 `isOk` 컬럼 `N`으로 수정
- 요청 거부시 보낼 Dto 생성
- `refuseRequest`
        1. 해당 그룹의 소속이 아닌 사람이 요청거부를 한다면 `IllegalArgument`
        2. 해당 그룹 소속이지만 관리자가 아닌 사람이 요청 거부를 한다면 `IllegalArgument`
        3. 모든 걸 만족하면 컬럼 `N`으로 수정
- `UserService`에서 여러 사용자 가입 로직 비밀번호 암호화 로직 추가