### PR TITLE
[feat] 요청 승락 구현

### DIFF
--- a/src/main/java/com/FINAL/KIP/request/controller/RequestController.java
+++ b/src/main/java/com/FINAL/KIP/request/controller/RequestController.java
@@ -1,6 +1,7 @@
 package com.FINAL.KIP.request.controller;
 
 import com.FINAL.KIP.request.dto.request.RequestCreateReqDto;
+import com.FINAL.KIP.request.dto.response.RequestAgreeResDto;
 import com.FINAL.KIP.request.dto.response.RequestCreateResDto;
 import com.FINAL.KIP.request.dto.response.RequestRefuseResDto;
 import com.FINAL.KIP.request.service.RequestService;
@@ -30,6 +31,11 @@ public class RequestController {
 	@GetMapping("/doc/request/refuse/{request_id}")
 	public ResponseEntity<RequestRefuseResDto> refuseRequest(@PathVariable Long request_id) {
 		return requestService.refuseRequest(request_id);
+	}
+
+	@GetMapping("/doc/request/agree/{request_id}")
+	public ResponseEntity<RequestAgreeResDto> agreeRequest(@PathVariable Long request_id) {
+		return requestService.agreeRequest(request_id);
 	}
 
 }

--- a/src/main/java/com/FINAL/KIP/request/domain/Request.java
+++ b/src/main/java/com/FINAL/KIP/request/domain/Request.java
@@ -51,4 +51,8 @@ public class Request extends BaseEntity {
 	public void refuseRequest() {
 		this.isOk = "N";
 	}
+	public void agreeRequest() {
+		this.isOk = "Y";
+		this.dueDate = LocalDateTime.now().plusDays(days);
+	}
 }

--- a/src/main/java/com/FINAL/KIP/request/dto/response/RequestAgreeResDto.java
+++ b/src/main/java/com/FINAL/KIP/request/dto/response/RequestAgreeResDto.java
@@ -1,0 +1,15 @@
+package com.FINAL.KIP.request.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RequestAgreeResDto {
+
+	String title;
+	String name;
+	LocalDateTime dueDate;
+
+}

--- a/src/main/java/com/FINAL/KIP/request/service/RequestService.java
+++ b/src/main/java/com/FINAL/KIP/request/service/RequestService.java
@@ -9,6 +9,7 @@ import com.FINAL.KIP.group.domain.GroupUserId;
 import com.FINAL.KIP.group.repository.GroupUserRepository;
 import com.FINAL.KIP.request.domain.Request;
 import com.FINAL.KIP.request.dto.request.RequestCreateReqDto;
+import com.FINAL.KIP.request.dto.response.RequestAgreeResDto;
 import com.FINAL.KIP.request.dto.response.RequestCreateResDto;
 import com.FINAL.KIP.request.dto.response.RequestRefuseResDto;
 import com.FINAL.KIP.request.repository.RequestRepository;
@@ -128,11 +129,37 @@ public class RequestService {
 
 	private Request findById(Long requestId) {
 		return requestRepository.findById(requestId)
-			.orElseThrow(() -> new IllegalArgumentException("해당 문서가 존재하지 않습니다."));
+			.orElseThrow(() -> new IllegalArgumentException("해당 요청이 존재하지 않습니다."));
 	}
 
 	private User findByEmployeeId(String employeeId) {
 		return userRepository.findByEmployeeId(employeeId)
 			.orElseThrow(() -> new IllegalArgumentException("사번이 잘못되었습니다."));
+	}
+
+	@Transactional
+	public ResponseEntity<RequestAgreeResDto> agreeRequest(Long requestId) {
+		Request req = findById(requestId);
+
+		String employeeId = SecurityContextHolder.getContext().getAuthentication().getName();
+		User user = findByEmployeeId(employeeId);
+		Group group = req.getGroup();
+
+		GroupUser groupUser = findGroupUser(group, user);
+		if(groupUser == null) {
+			throw new IllegalArgumentException("해당 그룹 요청에 접근 권한이 존재하지 않습니다.");
+		}
+		if (groupUser.getGroupRole() != GroupRole.SUPER) {
+			throw new IllegalArgumentException("그룹의 관리자만 요청을 관리할 수 있습니다.");
+		}
+
+		req.agreeRequest();
+
+		RequestAgreeResDto requestAgreeResDto = new RequestAgreeResDto();
+		requestAgreeResDto.setName(req.getRequester().getName());
+		requestAgreeResDto.setDueDate(req.getDueDate());
+		requestAgreeResDto.setTitle(req.getDocument().getTitle());
+
+		return ResponseEntity.ok(requestAgreeResDto);
 	}
 }


### PR DESCRIPTION
- 요청 승락 위한 `Controller` 구현
- 요청 승락 시에 `isOk` `Y`로 변경 및 `dueDate` 현재시간에 `days` 더한 값으로 변경
- Dto 생성
- 요청 수락할때, 그룹내 유저인지, 슈퍼 유저인지 검증후 진행