### PR TITLE
Document patch

### DIFF
--- a/src/main/java/com/FINAL/KIP/document/controller/DocumentController.java
+++ b/src/main/java/com/FINAL/KIP/document/controller/DocumentController.java
@@ -3,6 +3,7 @@ package com.FINAL.KIP.document.controller;
 
 import com.FINAL.KIP.document.dto.req.CreateDocumentReqDto;
 import com.FINAL.KIP.document.dto.req.moveDocInGroupReqDto;
+import com.FINAL.KIP.document.dto.req.updateDocGroupReqDto;
 import com.FINAL.KIP.document.dto.res.DocumentResDto;
 import com.FINAL.KIP.document.dto.res.GetDocumentResDto;
 import com.FINAL.KIP.document.dto.res.PublicDocResDto;
@@ -57,6 +58,12 @@ public class DocumentController {
     @PatchMapping("{DocumentId}/type")
     public ResponseEntity<DocumentResDto> updateDocumentType(@PathVariable Long DocumentId){
         return ResponseEntity.ok(documentService.updateDocumentType(DocumentId));
+    }
+
+    @PatchMapping("group")
+    public ResponseEntity<DocumentResDto> updateDocumentGroup(@RequestBody updateDocGroupReqDto dto){
+        return ResponseEntity.ok(documentService.updateDocumentGroup(dto));
+
     }
 
 

--- a/src/main/java/com/FINAL/KIP/document/controller/DocumentController.java
+++ b/src/main/java/com/FINAL/KIP/document/controller/DocumentController.java
@@ -60,7 +60,12 @@ public class DocumentController {
         return ResponseEntity.ok(documentService.updateDocumentType(DocumentId));
     }
 
-    @PatchMapping("group")
+    @PatchMapping("{DocumentId}/public")
+    public ResponseEntity<DocumentResDto> updateDocumentPublic(@PathVariable Long DocumentId){
+        return ResponseEntity.ok(documentService.updateDocumentPublic(DocumentId));
+    }
+
+    @PatchMapping("group") // 전체공개에서 그룹으로 부여하는거 만드는 중 
     public ResponseEntity<DocumentResDto> updateDocumentGroup(@RequestBody updateDocGroupReqDto dto){
         return ResponseEntity.ok(documentService.updateDocumentGroup(dto));
 

--- a/src/main/java/com/FINAL/KIP/document/controller/DocumentController.java
+++ b/src/main/java/com/FINAL/KIP/document/controller/DocumentController.java
@@ -3,7 +3,7 @@ package com.FINAL.KIP.document.controller;
 
 import com.FINAL.KIP.document.dto.req.CreateDocumentReqDto;
 import com.FINAL.KIP.document.dto.req.moveDocInGroupReqDto;
-import com.FINAL.KIP.document.dto.req.updateDocGroupReqDto;
+import com.FINAL.KIP.document.dto.req.updateDocGroupIdReqDto;
 import com.FINAL.KIP.document.dto.res.DocumentResDto;
 import com.FINAL.KIP.document.dto.res.GetDocumentResDto;
 import com.FINAL.KIP.document.dto.res.PublicDocResDto;
@@ -65,9 +65,9 @@ public class DocumentController {
         return ResponseEntity.ok(documentService.updateDocumentPublic(DocumentId));
     }
 
-    @PatchMapping("group") // 전체공개에서 그룹으로 부여하는거 만드는 중 
-    public ResponseEntity<DocumentResDto> updateDocumentGroup(@RequestBody updateDocGroupReqDto dto){
-        return ResponseEntity.ok(documentService.updateDocumentGroup(dto));
+    @PatchMapping("group")
+    public ResponseEntity<DocumentResDto> updatePublicDocumentGroupId(@RequestBody updateDocGroupIdReqDto dto){
+        return ResponseEntity.ok(documentService.updatePublicDocumentGroupId(dto));
 
     }
 

--- a/src/main/java/com/FINAL/KIP/document/controller/DocumentController.java
+++ b/src/main/java/com/FINAL/KIP/document/controller/DocumentController.java
@@ -4,6 +4,7 @@ package com.FINAL.KIP.document.controller;
 import com.FINAL.KIP.document.dto.req.CreateDocumentReqDto;
 import com.FINAL.KIP.document.dto.req.moveDocInGroupReqDto;
 import com.FINAL.KIP.document.dto.req.updateDocGroupIdReqDto;
+import com.FINAL.KIP.document.dto.req.updateDocTitleReqDto;
 import com.FINAL.KIP.document.dto.res.DocumentResDto;
 import com.FINAL.KIP.document.dto.res.GetDocumentResDto;
 import com.FINAL.KIP.document.dto.res.PublicDocResDto;
@@ -50,25 +51,30 @@ public class DocumentController {
 
 
 //  Update
-    @PatchMapping("move")
+
+    @PatchMapping("title")
+    public ResponseEntity<DocumentResDto> updateDocumentTitle(@RequestBody updateDocTitleReqDto dto){
+        return ResponseEntity.ok(documentService.updateDocumentTitle(dto));
+    }
+
+    @PatchMapping("move") // 그룹내 문서 이동
     public ResponseEntity<List<GetDocumentResDto>> moveDocumentInGroup(@RequestBody moveDocInGroupReqDto dto){
         return ResponseEntity.ok(documentService.moveDocumentInGroup(dto));
     }
 
-    @PatchMapping("{DocumentId}/type")
+    @PatchMapping("{DocumentId}/type") // 문서 섹션, 컨텐츠 변경
     public ResponseEntity<DocumentResDto> updateDocumentType(@PathVariable Long DocumentId){
         return ResponseEntity.ok(documentService.updateDocumentType(DocumentId));
     }
 
-    @PatchMapping("{DocumentId}/public")
+    @PatchMapping("{DocumentId}/public") // 그룹문서 => 전체공개
     public ResponseEntity<DocumentResDto> updateDocumentPublic(@PathVariable Long DocumentId){
         return ResponseEntity.ok(documentService.updateDocumentPublic(DocumentId));
     }
 
-    @PatchMapping("group")
+    @PatchMapping("group") // 전체공개 => 그룹문서
     public ResponseEntity<DocumentResDto> updatePublicDocumentGroupId(@RequestBody updateDocGroupIdReqDto dto){
         return ResponseEntity.ok(documentService.updatePublicDocumentGroupId(dto));
-
     }
 
 

--- a/src/main/java/com/FINAL/KIP/document/dto/req/updateDocGroupIdReqDto.java
+++ b/src/main/java/com/FINAL/KIP/document/dto/req/updateDocGroupIdReqDto.java
@@ -5,8 +5,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class updateDocGroupReqDto {
+public class updateDocGroupIdReqDto {
     private Long targetDocumentId;
     private Long targetGroupId;
 }
-    

--- a/src/main/java/com/FINAL/KIP/document/dto/req/updateDocGroupReqDto.java
+++ b/src/main/java/com/FINAL/KIP/document/dto/req/updateDocGroupReqDto.java
@@ -1,0 +1,11 @@
+package com.FINAL.KIP.document.dto.req;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class updateDocGroupReqDto {
+    private Long targetDocumentId;
+    private Long targetGroupId;
+}

--- a/src/main/java/com/FINAL/KIP/document/dto/req/updateDocGroupReqDto.java
+++ b/src/main/java/com/FINAL/KIP/document/dto/req/updateDocGroupReqDto.java
@@ -9,3 +9,4 @@ public class updateDocGroupReqDto {
     private Long targetDocumentId;
     private Long targetGroupId;
 }
+    

--- a/src/main/java/com/FINAL/KIP/document/dto/req/updateDocTitleReqDto.java
+++ b/src/main/java/com/FINAL/KIP/document/dto/req/updateDocTitleReqDto.java
@@ -1,0 +1,11 @@
+package com.FINAL.KIP.document.dto.req;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class updateDocTitleReqDto {
+    private Long targetDocumentId;
+    private String newTitle;
+}

--- a/src/main/java/com/FINAL/KIP/document/dto/res/DocumentResDto.java
+++ b/src/main/java/com/FINAL/KIP/document/dto/res/DocumentResDto.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 public class DocumentResDto {
 
+    private final Long documentId;
     private final String title;
     private final KmsDocType kmsDocType;
     private Long upLinkId;
@@ -17,6 +18,7 @@ public class DocumentResDto {
     private String groupName;
 
     public DocumentResDto(Document document) {
+        this.documentId = document.getId();
         this.title = document.getTitle();
         this.kmsDocType = document.getKmsDocType();
 

--- a/src/main/java/com/FINAL/KIP/document/dto/res/GetDocumentResDto.java
+++ b/src/main/java/com/FINAL/KIP/document/dto/res/GetDocumentResDto.java
@@ -1,14 +1,19 @@
 package com.FINAL.KIP.document.dto.res;
 
 import com.FINAL.KIP.document.domain.Document;
+import com.FINAL.KIP.document.domain.KmsDocType;
 import lombok.Getter;
 
 @Getter
 public class GetDocumentResDto {
 
+    private final Long documentId;
+    private final KmsDocType docType;
     private final String title;
 
     public GetDocumentResDto(Document document, Boolean isAccssible){
+        this.documentId = document.getId();
+        this.docType = document.getKmsDocType();
         if(isAccssible)
             this.title = document.getTitle();
         else

--- a/src/main/java/com/FINAL/KIP/document/dto/res/PublicDocResDto.java
+++ b/src/main/java/com/FINAL/KIP/document/dto/res/PublicDocResDto.java
@@ -7,12 +7,14 @@ import lombok.Getter;
 @Getter
 public class PublicDocResDto {
 
+    private final Long documentId;
     private final String discription = "전체공개";
     private final String title;
     private final KmsDocType kmsDocType;
 
 
     public PublicDocResDto(Document document) {
+        this.documentId = document.getId();
         this.title = document.getTitle();
         this.kmsDocType = document.getKmsDocType();
     }

--- a/src/main/java/com/FINAL/KIP/document/service/DocumentService.java
+++ b/src/main/java/com/FINAL/KIP/document/service/DocumentService.java
@@ -4,6 +4,7 @@ import com.FINAL.KIP.document.domain.Document;
 import com.FINAL.KIP.document.domain.KmsDocType;
 import com.FINAL.KIP.document.dto.req.CreateDocumentReqDto;
 import com.FINAL.KIP.document.dto.req.moveDocInGroupReqDto;
+import com.FINAL.KIP.document.dto.req.updateDocGroupReqDto;
 import com.FINAL.KIP.document.dto.res.DocumentResDto;
 import com.FINAL.KIP.document.dto.res.GetDocumentResDto;
 import com.FINAL.KIP.document.dto.res.PublicDocResDto;
@@ -155,6 +156,22 @@ public class DocumentService {
             targetDocument.setKmsDocType(KmsDocType.SECTION);
         else
             targetDocument.setKmsDocType(KmsDocType.CONTENT);
+        return new DocumentResDto(targetDocument);
+    }
+
+    @Transactional
+    public DocumentResDto updateDocumentGroup (updateDocGroupReqDto dto){
+
+        Document targetDocument = getDocumentById(dto.getTargetDocumentId());
+        Group targetGroup = null;
+
+        if (dto.getTargetGroupId() != null) { // 전체공개가 아닌 경우
+            targetGroup = groupService.getGroupById(dto.getTargetGroupId());
+
+            Document topDocumentInTargetGroup = getTopDocument(targetGroup);
+        }
+
+        targetDocument.setGroup(targetGroup);
         return new DocumentResDto(targetDocument);
     }
 

--- a/src/main/java/com/FINAL/KIP/document/service/DocumentService.java
+++ b/src/main/java/com/FINAL/KIP/document/service/DocumentService.java
@@ -5,6 +5,7 @@ import com.FINAL.KIP.document.domain.KmsDocType;
 import com.FINAL.KIP.document.dto.req.CreateDocumentReqDto;
 import com.FINAL.KIP.document.dto.req.moveDocInGroupReqDto;
 import com.FINAL.KIP.document.dto.req.updateDocGroupIdReqDto;
+import com.FINAL.KIP.document.dto.req.updateDocTitleReqDto;
 import com.FINAL.KIP.document.dto.res.DocumentResDto;
 import com.FINAL.KIP.document.dto.res.GetDocumentResDto;
 import com.FINAL.KIP.document.dto.res.PublicDocResDto;
@@ -117,6 +118,12 @@ public class DocumentService {
 
 
     //    Update
+    public DocumentResDto updateDocumentTitle(updateDocTitleReqDto dto) {
+        Document targetDocument = getDocumentById(dto.getTargetDocumentId());
+        targetDocument.setTitle(dto.getNewTitle());
+        return new DocumentResDto(documentRepo.save(targetDocument));
+    }
+
     @Transactional
     public List<GetDocumentResDto> moveDocumentInGroup(moveDocInGroupReqDto dto) throws IllegalArgumentException {
 
@@ -208,8 +215,8 @@ public class DocumentService {
         return new DocumentResDto(targetDocument);
     }
 
-
     //    Delete
+
     @Transactional
     public void deleteDocument(Long documentId) throws IllegalArgumentException {
         Document tagetDocument = getDocumentById(documentId);
@@ -227,8 +234,8 @@ public class DocumentService {
         }
     }
 
-
     //    공통함수
+
     public Document getDocumentById(Long documentId) throws NoSuchElementException {
         return documentRepo.findById(documentId)
                 .orElseThrow(() -> new NoSuchElementException("찾으시려는 문서 ID와 일치하는 문서가 없습니다."));


### PR DESCRIPTION
src/main/java/com/FINAL/KIP/document/controller/DocumentController.java
 - updateDocumentPublic, 그룹문서 전체공개로 변경
 - updateDocumentGroup, 전체공개 문서 소속그룹 부여
 
 src/main/java/com/FINAL/KIP/document/dto/req/updateDocGroupReqDto.java
 - 전체공개 문서 소속그룹 부여 함수에서 사용할 dto
 - 로직은 코드참고. 
 - 함수에 예외처리 붙여줌