### PR TITLE
[feat] 유저 정보 업데이트 / 유저 삭제

### DIFF
--- a/src/main/java/com/FINAL/KIP/common/InitialDataLoader.java
+++ b/src/main/java/com/FINAL/KIP/common/InitialDataLoader.java
@@ -21,7 +21,7 @@ public InitialDataLoader(UserRepository userRepository, PasswordEncoder password
     public void run(String... args) throws Exception {
         if (userRepository.findByEmployeeId("KK").isEmpty()) {
             User adminMember = User.builder()
-                    .name("admin")
+                    .name("admin1")
                     .email("admin@test.com")
                     .password(passwordEncoder.encode("1234"))
                     .phoneNumber("01012345678")

--- a/src/main/java/com/FINAL/KIP/user/controller/UserController.java
+++ b/src/main/java/com/FINAL/KIP/user/controller/UserController.java
@@ -5,11 +5,13 @@ import com.FINAL.KIP.securities.JwtTokenProvider;
 import com.FINAL.KIP.user.domain.User;
 import com.FINAL.KIP.user.dto.req.CreateUserReqDto;
 import com.FINAL.KIP.user.dto.req.LoginReqDto;
+import com.FINAL.KIP.user.dto.req.UserInfoUpdateReqDto;
 import com.FINAL.KIP.user.dto.res.UserResDto;
 import com.FINAL.KIP.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
@@ -56,6 +58,11 @@ public class UserController {
         return new ResponseEntity<>(commonResponse, HttpStatus.OK);
     }
 
+    @PatchMapping
+    public ResponseEntity<CommonResponse> userUpdate(@RequestBody UserInfoUpdateReqDto userInfoUpdateReqDto){
+        userService.update(userInfoUpdateReqDto);
+        return new ResponseEntity<>(new CommonResponse(HttpStatus.OK, "User updated successfully", userInfoUpdateReqDto.getName()), HttpStatus.OK);
+    }
 
 
 

--- a/src/main/java/com/FINAL/KIP/user/controller/UserController.java
+++ b/src/main/java/com/FINAL/KIP/user/controller/UserController.java
@@ -46,24 +46,33 @@ public class UserController {
         return ResponseEntity.ok(userService.getAllUsers());
     }
 
+    // 로그인
     @PostMapping("login") //login은 토큰 사용으로 Map형식으로 받아주어야함 // Map<String, Object>
     public ResponseEntity<CommonResponse> userLogin(@RequestBody LoginReqDto loginReqDto) {
         CommonResponse commonResponse = userService.login(loginReqDto);
         return new ResponseEntity<>(commonResponse, HttpStatus.OK);
     }
 
+    // 사용자 마이페이지
     @GetMapping("mypage")
     public ResponseEntity<CommonResponse> myPage() {
         CommonResponse commonResponse = userService.mypage();
         return new ResponseEntity<>(commonResponse, HttpStatus.OK);
     }
 
+    // 사용자 정보 업데이트
     @PatchMapping
     public ResponseEntity<CommonResponse> userUpdate(@RequestBody UserInfoUpdateReqDto userInfoUpdateReqDto){
         userService.update(userInfoUpdateReqDto);
         return new ResponseEntity<>(new CommonResponse(HttpStatus.OK, "User updated successfully", userInfoUpdateReqDto.getName()), HttpStatus.OK);
     }
 
+    // 사용자 회원 삭제
+    @DeleteMapping("{employeeId}")
+    public ResponseEntity<CommonResponse> userDelete(@PathVariable(value = "employeeId") String employeeId){
+        userService.delete(employeeId);
+        return new ResponseEntity<>(new CommonResponse(HttpStatus.OK, "User deleted successfully", employeeId), HttpStatus.OK);
+    }
 
 
 //        User user = userService.login(loginReqDto);

--- a/src/main/java/com/FINAL/KIP/user/domain/User.java
+++ b/src/main/java/com/FINAL/KIP/user/domain/User.java
@@ -37,7 +37,7 @@ public class User extends BaseEntity {
 
     private LocalDateTime employedDay;
 
-    @Column(nullable = false)
+    @Column(unique = true, nullable = false)
     private String employeeId;
 
     @Column(nullable = false)
@@ -64,6 +64,13 @@ public class User extends BaseEntity {
         this.employedDay = employedDay;
         this.employeeId = employeeId;
         this.role = role;
+    }
+
+    public void updateUserInfo(String name, String email, String phoneNumber) {
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+
     }
 
 }

--- a/src/main/java/com/FINAL/KIP/user/dto/req/UserInfoUpdateReqDto.java
+++ b/src/main/java/com/FINAL/KIP/user/dto/req/UserInfoUpdateReqDto.java
@@ -1,0 +1,10 @@
+package com.FINAL.KIP.user.dto.req;
+
+import lombok.Data;
+
+@Data
+public class UserInfoUpdateReqDto {
+    private String name;
+    private String email;
+    private String phoneNumber;
+}

--- a/src/main/java/com/FINAL/KIP/user/service/UserService.java
+++ b/src/main/java/com/FINAL/KIP/user/service/UserService.java
@@ -118,4 +118,14 @@ public class UserService {
         userInfo.updateUserInfo(userInfoUpdateReqDto.getName(), userInfoUpdateReqDto.getEmail(),
                 userInfoUpdateReqDto.getPhoneNumber());
     }
+
+    @Transactional
+    @PreAuthorize("hasAuthority('ADMIN')")
+    public void delete(String employeeId){
+//        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//        String employeeId = authentication.getName();
+        User userInfo = userRepo.findByEmployeeId(employeeId)
+                .orElseThrow(() -> new EntityNotFoundException("사원번호를 찾을 수 없습니다. " + employeeId));
+        userRepo.delete(userInfo);
+    }
 }

--- a/src/main/java/com/FINAL/KIP/user/service/UserService.java
+++ b/src/main/java/com/FINAL/KIP/user/service/UserService.java
@@ -7,6 +7,7 @@ import com.FINAL.KIP.securities.refresh.UserRefreshTokenRepository;
 import com.FINAL.KIP.user.domain.User;
 import com.FINAL.KIP.user.dto.req.CreateUserReqDto;
 import com.FINAL.KIP.user.dto.req.LoginReqDto;
+import com.FINAL.KIP.user.dto.req.UserInfoUpdateReqDto;
 import com.FINAL.KIP.user.dto.res.UserResDto;
 import com.FINAL.KIP.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -17,6 +18,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.List;
@@ -91,6 +93,7 @@ public class UserService {
                         () -> userRefreshTokenRepository.save(new UserRefreshToken(user, refreshToken))
                 );
         Map<String, String> result = new HashMap<>();
+        result.put("user_name", user.getName());
         result.put("access_token", accessToken);
         result.put("refresh_token", refreshToken);
         return new CommonResponse(HttpStatus.OK, "JWT token is created!", result);
@@ -103,6 +106,16 @@ public class UserService {
         User userInfo = userRepo.findByEmployeeId(employeeId)
                 .orElseThrow(() -> new EntityNotFoundException("사원번호를 찾을 수 없습니다. " + employeeId));
         return new CommonResponse(HttpStatus.OK, "User info loaded successfully!", userInfo);
+    }
 
+    @Transactional
+    @PreAuthorize("hasAuthority('ADMIN') or hasAuthority('USER')")
+    public void update(UserInfoUpdateReqDto userInfoUpdateReqDto){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String employeeId = authentication.getName();
+        User userInfo = userRepo.findByEmployeeId(employeeId)
+                .orElseThrow(() -> new EntityNotFoundException("사원번호를 찾을 수 없습니다. " + employeeId));
+        userInfo.updateUserInfo(userInfoUpdateReqDto.getName(), userInfoUpdateReqDto.getEmail(),
+                userInfoUpdateReqDto.getPhoneNumber());
     }
 }


### PR DESCRIPTION
**유저 정보 업데이트**
: 로그인 되어있는 유저 사원번호로 유저 확인 후 유저 정보 업데이트 진행
: 이름, 이메일, 전화번호 수정만 가능

***

**유저 삭제**
: 관리자가 사원번호로 유저삭제 가능(일반 유저는 삭제 불가)
: del Y/N이 아니라 유저 삭제시 DB에서 제거