### PR TITLE
[fix] request 생성 시 userId 제거

### DIFF
--- a/src/main/java/com/FINAL/KIP/request/dto/request/RequestCreateReqDto.java
+++ b/src/main/java/com/FINAL/KIP/request/dto/request/RequestCreateReqDto.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 public class RequestCreateReqDto {
 
 	private String docId;
-	private Long userId;
 	private int days;
 
 }

--- a/src/main/java/com/FINAL/KIP/request/service/RequestService.java
+++ b/src/main/java/com/FINAL/KIP/request/service/RequestService.java
@@ -56,7 +56,8 @@ public class RequestService {
 		RequestCreateReqDto requestCreateReqDto) throws IllegalArgumentException {
 
 		Document document = findDocumentByUuid(requestCreateReqDto.getDocId());
-		User user = findUserById(requestCreateReqDto.getUserId());
+		String userEmployeeId = SecurityContextHolder.getContext().getAuthentication().getName();
+		User user = findByEmployeeId(userEmployeeId);
 
 		if (requestRepository.existsRequestByRequesterAndDocumentAndIsOk(user, document, "P")) {
 			throw new IllegalArgumentException("이미 해당 문서에 접근 권한요청을 했습니다.");


### PR DESCRIPTION
 - RequestCreateReqDto에서 userId 삭제
 - RequestService애서 SecurityContextHolder에서 로그인된 유저의 정보 꺼내어 사용