### PR TITLE
[GroupUser] 그룹내 사용자 삭제

### DIFF
--- a/src/main/java/com/FINAL/KIP/document/service/DocumentService.java
+++ b/src/main/java/com/FINAL/KIP/document/service/DocumentService.java
@@ -216,7 +216,6 @@ public class DocumentService {
     }
 
     //    Delete
-
     @Transactional
     public void deleteDocument(Long documentId) throws IllegalArgumentException {
         Document tagetDocument = getDocumentById(documentId);
@@ -235,7 +234,6 @@ public class DocumentService {
     }
 
     //    공통함수
-
     public Document getDocumentById(Long documentId) throws NoSuchElementException {
         return documentRepo.findById(documentId)
                 .orElseThrow(() -> new NoSuchElementException("찾으시려는 문서 ID와 일치하는 문서가 없습니다."));

--- a/src/main/java/com/FINAL/KIP/group/controller/GroupController.java
+++ b/src/main/java/com/FINAL/KIP/group/controller/GroupController.java
@@ -1,6 +1,7 @@
 package com.FINAL.KIP.group.controller;
 
 
+import com.FINAL.KIP.group.domain.GroupUser;
 import com.FINAL.KIP.group.dto.req.CreateGroupReqDto;
 import com.FINAL.KIP.group.dto.req.UpdateGroupReqDto;
 import com.FINAL.KIP.group.dto.req.addUsersToGroupReqDto;
@@ -130,6 +131,14 @@ public class GroupController {
         return ResponseEntity.ok(
                 groupService.getMyGroups()
         );
+    }
+
+
+    // Update
+    @PatchMapping("{groupId}/{userId}/role")
+    public ResponseEntity<GroupUsersRoleResDto> updateUserRoleInGroup(
+            @PathVariable Long groupId, @PathVariable Long userId) {
+        return ResponseEntity.ok(groupService.updateUserRoleInGroup(groupId, userId));
     }
 
     //  Delete

--- a/src/main/java/com/FINAL/KIP/group/controller/GroupController.java
+++ b/src/main/java/com/FINAL/KIP/group/controller/GroupController.java
@@ -98,7 +98,7 @@ public class GroupController {
 
                             /* GroupUser */
 
-    //    Create
+    //  Create
     @PostMapping("addusers")
     public ResponseEntity<List<GroupUsersRoleResDto>> addUsersToGroup(
             @RequestBody addUsersToGroupReqDto dto) {
@@ -116,7 +116,7 @@ public class GroupController {
     }
 
 
-    //    Read
+    //  Read
     @GetMapping("{groupId}/users")
     public ResponseEntity<GroupUsersResDto> getGroupUsers(
             @PathVariable Long groupId) {
@@ -130,6 +130,13 @@ public class GroupController {
         return ResponseEntity.ok(
                 groupService.getMyGroups()
         );
+    }
+
+    //  Delete
+    @DeleteMapping("{groupId}/{userId}/delete")
+    public ResponseEntity<GroupUsersResDto> removeUserFromGroup(
+            @PathVariable Long groupId, @PathVariable Long userId) {
+        return ResponseEntity.ok(groupService.removeUserFromGroup(groupId, userId));
     }
 }
 

--- a/src/main/java/com/FINAL/KIP/group/domain/GroupUser.java
+++ b/src/main/java/com/FINAL/KIP/group/domain/GroupUser.java
@@ -21,13 +21,10 @@ public class GroupUser extends BaseEntity {
     @JoinColumn(nullable = false)
     @Id private User user;
 
-
+    @Setter
     @Enumerated(value = EnumType.STRING)
     @Column(nullable = false)
     private GroupRole groupRole;
-
-    @Setter
-    private String delYn = "N";
 
     public GroupUser(){}
 

--- a/src/main/java/com/FINAL/KIP/group/domain/GroupUserId.java
+++ b/src/main/java/com/FINAL/KIP/group/domain/GroupUserId.java
@@ -1,18 +1,24 @@
 package com.FINAL.KIP.group.domain;
 
 import com.FINAL.KIP.user.domain.User;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.io.Serializable;
 
 @Getter
-@Setter
 @EqualsAndHashCode
 public class GroupUserId implements Serializable {
 
     private Group group;
     private User user;
 
+    public GroupUserId() {}
+
+    @Builder
+    public GroupUserId (Group group, User user) {
+        this.group = group;
+        this.user = user;
+    }
 }

--- a/src/main/java/com/FINAL/KIP/group/service/GroupService.java
+++ b/src/main/java/com/FINAL/KIP/group/service/GroupService.java
@@ -4,6 +4,7 @@ import com.FINAL.KIP.common.aspect.JustAdmin;
 import com.FINAL.KIP.common.aspect.UserAdmin;
 import com.FINAL.KIP.group.domain.Group;
 import com.FINAL.KIP.group.domain.GroupUser;
+import com.FINAL.KIP.group.domain.GroupUserId;
 import com.FINAL.KIP.group.domain.UserIdAndGroupRole;
 import com.FINAL.KIP.group.dto.req.CreateGroupReqDto;
 import com.FINAL.KIP.group.dto.req.UpdateGroupReqDto;
@@ -113,8 +114,8 @@ public class GroupService {
                 .collect(Collectors.toList());
     }
 
-    //  Update
 
+    //  Update
     @JustAdmin
     public GroupResDto updateGroupInfo(UpdateGroupReqDto dto) {
         Group group = getGroupById(dto.getGroupId());
@@ -124,8 +125,8 @@ public class GroupService {
         return new GroupResDto(groupRepo.save(group));
     }
 
-    //  Delete
 
+    //  Delete
     @JustAdmin
     public void deleteGroup(Long groupId) {
         Group targetGroup = getGroupById(groupId);
@@ -134,6 +135,14 @@ public class GroupService {
         if (targetGroup.getDocuments().size() > 1)
             throw new IllegalStateException("그룹에 최상단문서 1개만 남기고 모두 지워야 삭제 가능합니다.");
         groupRepo.delete(targetGroup);
+    }
+
+
+    @JustAdmin
+    public GroupUsersResDto removeUserFromGroup(Long groupId, Long userId) {
+        GroupUser groupUser = getGroupUserByGroupUserId(groupId, userId);
+        groupUserRepo.delete(groupUser);
+        return getGroupUsers(groupId);
     }
 
     //  공통함수
@@ -196,5 +205,16 @@ public class GroupService {
         return groupRepo.findAll().stream()
                 .map(GroupResDto::new)
                 .collect(Collectors.toList());
+    }
+
+    @JustAdmin
+    public GroupUser getGroupUserByGroupUserId(Long groupId, Long userId) {
+        GroupUserId groupUserId = GroupUserId.builder()
+                .group(getGroupById(groupId))
+                .user(userService.getUserById(userId))
+                .build();
+        return groupUserRepo.findById(groupUserId)
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "그룹 유저 아이디로 검색할 수 있는 그룹 유저가 없습니다. groupId: " + groupId + ", userId: " + userId));
     }
 }

--- a/src/main/java/com/FINAL/KIP/group/service/GroupService.java
+++ b/src/main/java/com/FINAL/KIP/group/service/GroupService.java
@@ -2,10 +2,7 @@ package com.FINAL.KIP.group.service;
 
 import com.FINAL.KIP.common.aspect.JustAdmin;
 import com.FINAL.KIP.common.aspect.UserAdmin;
-import com.FINAL.KIP.group.domain.Group;
-import com.FINAL.KIP.group.domain.GroupUser;
-import com.FINAL.KIP.group.domain.GroupUserId;
-import com.FINAL.KIP.group.domain.UserIdAndGroupRole;
+import com.FINAL.KIP.group.domain.*;
 import com.FINAL.KIP.group.dto.req.CreateGroupReqDto;
 import com.FINAL.KIP.group.dto.req.UpdateGroupReqDto;
 import com.FINAL.KIP.group.dto.req.addUsersToGroupReqDto;
@@ -125,6 +122,15 @@ public class GroupService {
         return new GroupResDto(groupRepo.save(group));
     }
 
+    @JustAdmin
+    public GroupUsersRoleResDto updateUserRoleInGroup(Long groupId, Long userId) {
+        GroupUser groupUser = getGroupUserByGroupUserId(groupId, userId);
+        if (groupUser.getGroupRole().equals(GroupRole.SUPER))
+            groupUser.setGroupRole(GroupRole.NORMAL);
+        else
+            groupUser.setGroupRole(GroupRole.SUPER);
+        return new GroupUsersRoleResDto(groupUserRepo.save(groupUser));
+    }
 
     //  Delete
     @JustAdmin

--- a/src/main/java/com/FINAL/KIP/user/controller/UserController.java
+++ b/src/main/java/com/FINAL/KIP/user/controller/UserController.java
@@ -3,7 +3,6 @@ package com.FINAL.KIP.user.controller;
 import com.FINAL.KIP.common.CommonResponse;
 import com.FINAL.KIP.common.firebase.service.FCMService;
 import com.FINAL.KIP.securities.JwtTokenProvider;
-import com.FINAL.KIP.user.domain.User;
 import com.FINAL.KIP.user.dto.req.CreateUserReqDto;
 import com.FINAL.KIP.user.dto.req.LoginReqDto;
 import com.FINAL.KIP.user.dto.req.UserInfoUpdateReqDto;
@@ -12,12 +11,9 @@ import com.FINAL.KIP.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("user")

--- a/src/main/java/com/FINAL/KIP/user/domain/User.java
+++ b/src/main/java/com/FINAL/KIP/user/domain/User.java
@@ -1,17 +1,17 @@
 package com.FINAL.KIP.user.domain;
 
 import com.FINAL.KIP.common.domain.BaseEntity;
-import com.FINAL.KIP.document.domain.Document;
+import com.FINAL.KIP.group.domain.GroupUser;
 import com.FINAL.KIP.note.domain.Note;
 import com.FINAL.KIP.request.domain.Request;
 import jakarta.persistence.*;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Getter
@@ -49,10 +49,13 @@ public class User extends BaseEntity {
     private String delYn = "N";
 
     @OneToMany(mappedBy = "requester", cascade = CascadeType.ALL)
-    private List<Request> requests = new ArrayList<>();
+    private final List<Request> requests = new ArrayList<>();
 
     @OneToMany(mappedBy = "receiver", cascade = CascadeType.ALL)
-    private List<Note> notes = new ArrayList<>();
+    private final List<Note> notes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    private final List<GroupUser> groupUsers = new ArrayList<>();
 
     public User() {
 


### PR DESCRIPTION
src/main/java/com/FINAL/KIP/group/domain/GroupUserId.java
 - 복합키를 만들어서 조회하고, 삭제하는 방식으로 구현
 - 복합키(GroupUserId)로 조회하면 조회가 더 빠르다고함. 
 
 src/main/java/com/FINAL/KIP/group/service/GroupService.java
 - GroupUser 객체를 GroupUserId 로 찾아와서 객체로 삭제함
 
 src/main/java/com/FINAL/KIP/user/domain/User.java
  - user 삭제(탈퇴)시 그룹에 속한 User 정보도 삭제되도록 관계 추가. 