### PR TITLE
Request read, delete

### DIFF
--- a/src/main/java/com/FINAL/KIP/request/controller/RequestController.java
+++ b/src/main/java/com/FINAL/KIP/request/controller/RequestController.java
@@ -3,10 +3,12 @@ package com.FINAL.KIP.request.controller;
 import com.FINAL.KIP.request.dto.request.RequestCreateReqDto;
 import com.FINAL.KIP.request.dto.response.RequestAgreeResDto;
 import com.FINAL.KIP.request.dto.response.RequestCreateResDto;
+import com.FINAL.KIP.request.dto.response.RequestDeleteResDto;
 import com.FINAL.KIP.request.dto.response.RequestRefuseResDto;
 import com.FINAL.KIP.request.service.RequestService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,6 +38,11 @@ public class RequestController {
 	@GetMapping("/doc/request/agree/{request_id}")
 	public ResponseEntity<RequestAgreeResDto> agreeRequest(@PathVariable Long request_id) {
 		return requestService.agreeRequest(request_id);
+	}
+
+	@DeleteMapping("/doc/request/{request_id}")
+	public ResponseEntity<RequestDeleteResDto> deleteRequst(@PathVariable Long request_id) {
+		return requestService.deleteRequest(request_id);
 	}
 
 }

--- a/src/main/java/com/FINAL/KIP/request/controller/RequestController.java
+++ b/src/main/java/com/FINAL/KIP/request/controller/RequestController.java
@@ -4,10 +4,13 @@ import com.FINAL.KIP.request.dto.request.RequestCreateReqDto;
 import com.FINAL.KIP.request.dto.response.RequestAgreeResDto;
 import com.FINAL.KIP.request.dto.response.RequestCreateResDto;
 import com.FINAL.KIP.request.dto.response.RequestDeleteResDto;
+import com.FINAL.KIP.request.dto.response.RequestReadResDto;
 import com.FINAL.KIP.request.dto.response.RequestRefuseResDto;
 import com.FINAL.KIP.request.service.RequestService;
+import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,7 +29,8 @@ public class RequestController {
 
 
 	@GetMapping("/doc/request")
-	public ResponseEntity<RequestCreateResDto> createRequest(@RequestBody RequestCreateReqDto requestCreateReqDto) {
+	public ResponseEntity<RequestCreateResDto> createRequest(
+		@RequestBody RequestCreateReqDto requestCreateReqDto) {
 		return requestService.createRequest(requestCreateReqDto);
 	}
 
@@ -45,4 +49,8 @@ public class RequestController {
 		return requestService.deleteRequest(request_id);
 	}
 
+	@GetMapping("/group/{group_id}/request")
+	public ResponseEntity<List<RequestReadResDto>> readRequest(@PathVariable Long group_id) {
+		return requestService.readRequest(group_id);
+	}
 }

--- a/src/main/java/com/FINAL/KIP/request/domain/Request.java
+++ b/src/main/java/com/FINAL/KIP/request/domain/Request.java
@@ -34,6 +34,9 @@ public class Request extends BaseEntity {
 	@Builder.Default
 	private String isOk = "P";
 
+	@Builder.Default
+	private String delYn = "N";
+
 	private int days;
 
 	@ManyToOne
@@ -54,5 +57,8 @@ public class Request extends BaseEntity {
 	public void agreeRequest() {
 		this.isOk = "Y";
 		this.dueDate = LocalDateTime.now().plusDays(days);
+	}
+	public void deleteRequest() {
+		this.delYn = "Y";
 	}
 }

--- a/src/main/java/com/FINAL/KIP/request/dto/response/RequestDeleteResDto.java
+++ b/src/main/java/com/FINAL/KIP/request/dto/response/RequestDeleteResDto.java
@@ -1,0 +1,11 @@
+package com.FINAL.KIP.request.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class RequestDeleteResDto {
+
+	String message;
+}

--- a/src/main/java/com/FINAL/KIP/request/dto/response/RequestReadResDto.java
+++ b/src/main/java/com/FINAL/KIP/request/dto/response/RequestReadResDto.java
@@ -1,0 +1,18 @@
+package com.FINAL.KIP.request.dto.response;
+
+import com.FINAL.KIP.group.domain.Group;
+import com.FINAL.KIP.request.domain.Request;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class RequestReadResDto {
+
+	private String requester;
+	private String documentName;
+	private String isOk;
+
+}

--- a/src/main/java/com/FINAL/KIP/request/service/RequestService.java
+++ b/src/main/java/com/FINAL/KIP/request/service/RequestService.java
@@ -6,6 +6,7 @@ import com.FINAL.KIP.group.domain.Group;
 import com.FINAL.KIP.group.domain.GroupRole;
 import com.FINAL.KIP.group.domain.GroupUser;
 import com.FINAL.KIP.group.domain.GroupUserId;
+import com.FINAL.KIP.group.repository.GroupRepository;
 import com.FINAL.KIP.group.repository.GroupUserRepository;
 import com.FINAL.KIP.note.dto.request.NoteAgreeReqDto;
 import com.FINAL.KIP.note.dto.request.NoteCreateReqDto;
@@ -16,11 +17,15 @@ import com.FINAL.KIP.request.dto.request.RequestCreateReqDto;
 import com.FINAL.KIP.request.dto.response.RequestAgreeResDto;
 import com.FINAL.KIP.request.dto.response.RequestCreateResDto;
 import com.FINAL.KIP.request.dto.response.RequestDeleteResDto;
+import com.FINAL.KIP.request.dto.response.RequestReadResDto;
 import com.FINAL.KIP.request.dto.response.RequestRefuseResDto;
 import com.FINAL.KIP.request.repository.RequestRepository;
 import com.FINAL.KIP.user.domain.User;
 import com.FINAL.KIP.user.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -35,17 +40,20 @@ public class RequestService {
 	private final RequestRepository requestRepository;
 	private final DocumentRepository documentRepository;
 	private final UserRepository userRepository;
+	private final GroupRepository groupRepository;
 	private final NoteService noteService;
 
 	@Autowired
 	public RequestService(GroupUserRepository groupUserRepository,
 		RequestRepository requestRepository,
 		DocumentRepository documentRepository, UserRepository userRepository,
+		GroupRepository groupRepository,
 		NoteService noteService) {
 		this.groupUserRepository = groupUserRepository;
 		this.requestRepository = requestRepository;
 		this.documentRepository = documentRepository;
 		this.userRepository = userRepository;
+		this.groupRepository = groupRepository;
 		this.noteService = noteService;
 	}
 
@@ -211,5 +219,34 @@ public class RequestService {
 		req.deleteRequest();
 		RequestDeleteResDto requestDeleteResDto = new RequestDeleteResDto("삭제 완료되었습니다.");
 		return ResponseEntity.ok(requestDeleteResDto);
+	}
+
+	public ResponseEntity<List<RequestReadResDto>> readRequest(Long groupId) {
+
+		String employeeId = SecurityContextHolder.getContext().getAuthentication().getName();
+		User user = findByEmployeeId(employeeId);
+		Group group = findGroupById(groupId);
+		GroupUser groupByUser = findGroupByUser(group, user);
+		if (groupByUser.getGroupRole() != GroupRole.SUPER) {
+			throw new IllegalArgumentException("해당 그룹의 관리자가 아닙니다.");
+		}
+
+		List<RequestReadResDto> list = new ArrayList<>();
+		for (Request request : group.getRequests()) {
+			if(request.getDelYn().equals("Y"))
+				list.add(new RequestReadResDto(request.getRequester().getName(),
+					request.getDocument().getTitle(), request.getIsOk()));
+		}
+		return new ResponseEntity<>(list, HttpStatus.OK);
+	}
+
+	public GroupUser findGroupByUser(Group group,User user) {
+		return groupUserRepository.findByGroupAndUser(group, user)
+			.orElseThrow(() -> new IllegalArgumentException("그룹에 속해있지 않습니다."));
+	}
+
+	public Group findGroupById(long groupId) {
+		return groupRepository.findById(groupId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 그룹이 존재하지 않습니다."));
 	}
 }


### PR DESCRIPTION
 - Request delete

   1. Soft delete 방식으로 구현
   2. Request 엔티티에 delYn 컬럼 추가.
   3. 요청의 상태가 대기 상태일 경우 요청의 상태를 거절로 바꾸고 삭제

 - Request Read
   1. 그룹의 요청을 전부 가져오는 기능
   2. 요청의 delYn의 상태가 "N"(삭제되지 않은 경우)만 가져옴
   3. 해당 그룹의 관리자만 접근 가능